### PR TITLE
add json config help vscode display color

### DIFF
--- a/themes/Visual-Studio-Code/src/theme.js
+++ b/themes/Visual-Studio-Code/src/theme.js
@@ -32,6 +32,7 @@ const sunglo15 = setAlpha(sunglo, 0.15)
 
 export function getTheme(deprioritised = false) {
   return {
+    $schema: 'vscode://schemas/color-theme',
     name: 'Plastic',
     colors: {
       'activityBar.activeBorder': dodgerBlue,

--- a/themes/Visual-Studio-Code/themes/deprioritised-punctuation.json
+++ b/themes/Visual-Studio-Code/themes/deprioritised-punctuation.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "vscode://schemas/color-theme",
   "name": "Plastic",
   "colors": {
     "activityBar.activeBorder": "#1085FF",

--- a/themes/Visual-Studio-Code/themes/main.json
+++ b/themes/Visual-Studio-Code/themes/main.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "vscode://schemas/color-theme",
   "name": "Plastic",
   "colors": {
     "activityBar.activeBorder": "#1085FF",


### PR DESCRIPTION
Hi, I'm a fan of your theme, I noticed that the vscode config file was missing configuration to help vscode recognize colors, so I added it, here's a comparison
![image](https://user-images.githubusercontent.com/9017743/113479520-30e7dc80-94c2-11eb-97dd-49c25052881a.png)
